### PR TITLE
Process client feedback

### DIFF
--- a/resources/views/pages/contact/index.blade.php
+++ b/resources/views/pages/contact/index.blade.php
@@ -13,6 +13,9 @@
                         <p class="mt-4 text-xl font-medium">
                             {{ $page->sections->first()->flexible_text_block }}
                         </p>
+                        <p class="mt-4 text-lg font-semibold text-lotp-blue-500">
+                            Werkgebied: alleen Beetsterzwaag.
+                        </p>
 
                         <div class="flex flex-col lg:flex-row align-items-stretch justify-center w-full pt-8 shadow-lg ">
                             <div class="overflow-hidden bg-white rounded lg:max-w-xs w-full leading-normal">

--- a/resources/views/pages/homepage/partials/banner.blade.php
+++ b/resources/views/pages/homepage/partials/banner.blade.php
@@ -12,6 +12,9 @@
                 <p class="mt-4 text-xl font-medium">
                     {{ $page->sections->first()->flexible_text_block ?? ''}}
                 </p>
+                <p class="mt-4 text-lg font-semibold text-lotp-blue-500">
+                    Ik ben alleen beschikbaar voor honden in Beetsterzwaag.
+                </p>
             </div>
             <div class="flex gap-x-8 justify-center items-center mt-8">
                 <a href="{{ $page->sections->first()->flexible_button[0]['url'] }}"

--- a/resources/views/pages/homepage/partials/packages.blade.php
+++ b/resources/views/pages/homepage/partials/packages.blade.php
@@ -1,13 +1,18 @@
 @php
-    $types = ['Local Walks', 'Travel Walks'];
+    $types = ['Local Walks'];
 @endphp
 
 @forelse(range(0, count($types) - 1) as $index)
     <section class="container py-8 mx-auto">
         <div class="flex justify-center mt-12 mb-4">
-            <h3 class="font-bold font-ahsing tracking-wider text-4xl">
-                {{ $page->sections->get($index)->flexible_title }}
-            </h3>
+            <div class="text-center">
+                <h3 class="font-bold font-ahsing tracking-wider text-4xl">
+                    {{ $page->sections->get($index)->flexible_title }}
+                </h3>
+                <p class="mt-2 text-sm text-slate-600">
+                    Alle tarieven zijn voor wandelingen in Beetsterzwaag.
+                </p>
+            </div>
         </div>
         <div x-data="{ active: 0 }" class="grid gap-8 grid-cols-1 lg:grid-cols-2">
             @forelse ($prices->where('type', $types[$index]) as $price)
@@ -54,4 +59,3 @@
 @empty
 
 @endforelse
-

--- a/tests/Unit/ServiceAreaContentTest.php
+++ b/tests/Unit/ServiceAreaContentTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+class ServiceAreaContentTest extends TestCase
+{
+    public function test_packages_only_include_local_walks_type(): void
+    {
+        $template = file_get_contents(resource_path('views/pages/homepage/partials/packages.blade.php'));
+
+        $this->assertStringContainsString("$types = ['Local Walks'];", $template);
+        $this->assertStringNotContainsString('Travel Walks', $template);
+        $this->assertStringContainsString('Alle tarieven zijn voor wandelingen in Beetsterzwaag.', $template);
+    }
+
+    public function test_homepage_banner_mentions_beetsterzwaag_service_area(): void
+    {
+        $template = file_get_contents(resource_path('views/pages/homepage/partials/banner.blade.php'));
+
+        $this->assertStringContainsString('Ik ben alleen beschikbaar voor honden in Beetsterzwaag.', $template);
+    }
+
+    public function test_contact_page_mentions_beetsterzwaag_service_area(): void
+    {
+        $template = file_get_contents(resource_path('views/pages/contact/index.blade.php'));
+
+        $this->assertStringContainsString('Werkgebied: alleen Beetsterzwaag.', $template);
+    }
+}

--- a/tests/Unit/ServiceAreaContentTest.php
+++ b/tests/Unit/ServiceAreaContentTest.php
@@ -10,7 +10,7 @@ class ServiceAreaContentTest extends TestCase
     {
         $template = file_get_contents(resource_path('views/pages/homepage/partials/packages.blade.php'));
 
-        $this->assertStringContainsString("$types = ['Local Walks'];", $template);
+        $this->assertStringContainsString("\$types = ['Local Walks'];", $template);
         $this->assertStringNotContainsString('Travel Walks', $template);
         $this->assertStringContainsString('Alle tarieven zijn voor wandelingen in Beetsterzwaag.', $template);
     }


### PR DESCRIPTION
## TLDR
Fix literal assertion for packages type declaration. Changed 4 file(s): +46/-5 lines.

## Plan
Update `resources/views/pages/homepage/partials/packages.blade.php` to remove `Travel Walks` from the hard-coded `$types` array and render only the local category (plus existing daycare behavior if desired). Add Beetsterzwaag service-area messaging in templates such as `resources/views/pages/homepage/partials/banner.blade.php` and `resources/views/pages/contact/index.blade.php` (or another agreed subset). Optionally add a small note near pricing section header clarifying service area. Do not change Nova or database schema.

---
*Generated by Codex Runner*